### PR TITLE
Modifications to enable alert send as well as create

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,0 +1,7 @@
+CHANGELOG
+
+1.1.0.2 : Feb 2015
+
+ - Bumped version from 1.0.1
+ - added --action, --creator, --recipient and --recipient_id parameters and associated functionality:
+ - modified manpage; added examples and JSON structure.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ This is a shell script, to be used from the command line. For example:
 
 ```
   bin/python mailcivi.py --sitekey={key} --apikey={key} \
-      --name "Test mailing" --subject "My First Mailing" --from_id 1
+      --name "Test mailing" --subject "My First Mailing" --from_id 1 \
       --civicrm=http://crm.example.org/sites/all/modules/civicrm \
       --html=file.html
 ```

--- a/docs/mailcivi.man
+++ b/docs/mailcivi.man
@@ -7,6 +7,15 @@ mailcivi \- read mailing body text and create a mail template from it in CiviCRM
 .RB [ \-vh ]
 .RB [ \--civicrm
 .IR url ]
+.RB [ \--action
+.RB {
+.IR nothing
+.R |
+.IR create
+.R |
+.IR send
+.RI }
+.IB ]
 .RB [ \--sitekey
 .IR key ]
 .RB [ \--apikey
@@ -17,11 +26,17 @@ mailcivi \- read mailing body text and create a mail template from it in CiviCRM
 .IR subject ]
 .RB [ \--from_id
 .IR id ]
+.RB [ \--to_id
+.IR id ]
+.RB [ \--to_name
+.IR groupname ]
 .RB [ \--json
 .IR file ]
 .RB [ \--url
 .IR url ]
 .RB [ \--html
+.IR file ]
+.RB [ \--text
 .IR file ]
 .RB [ \--text
 .IR file ]
@@ -46,6 +61,17 @@ Specify the URL for the remote CiviCRM instance. The URL must include the path t
 civicrm module, and not just the homepage. For example in Drupal/Civi:
 .BR http://example.com/sites/all/modules/civicrm .
 .TP
+.B \-\-action " action"
+What to do:
+.RS
+.IP \(bu 4
+"nothing" \- do not create a template or send it.
+.IP \(bu 4
+"create" \- create a template on CiviCRM but do not send it.
+.IP \(bu 4
+"send" \- create a template on CiviCRM and also send it, if the recipient group has also been defined.
+.RE
+.TP
 .B \-\-sitekey " key"
 The CiviCRM site key, which is part of the installation configuration.
 .TP
@@ -54,19 +80,27 @@ The user's API key, which is part of the user profile. There is no user-interfac
 .I CiviCRM
 to create an api key.
 .TP
-.B \-\-name " name"
+.BR \-\-name " name "
 A string which will be used to name the mail template within
 .I CiviCRM
 but which is not visible to email recipients.
 .TP
-.B \-\-subject " subject"
+.BR \-\-subject " subject "
 A string which will be used as the proposed subject line in the new mail template.
 .TP
-.B \-\-from_id " id"
+.BR \-\-from_id " id "
 A small integer identifying the CiviCRM user which will own the mail template and which
 by default will be named as the sender of any email.
 .TP
-.B \-\-json " file"
+.BR \-\-to_id " id "
+A small integer identifying the CiviCRM group ID to which this template will be addressed.
+Only used if 'action' is 'send'. Only one of to_id or to_name can be set.
+.TP
+.BR \-\-to_name " name "
+A small integer identifying the CiviCRM group name to which this template will be addressed.
+Only used if 'action' is 'send'. Only one of to_id or to_name can be set.
+.TP
+.BR \-\-json " file"
 A file containing JSON-encoded data in four fields:
 .RS
 .IP \(bu 4
@@ -78,8 +112,61 @@ A file containing JSON-encoded data in four fields:
 .IP \(bu 4
 "html" \- a file containing the HTML version of the body of the email template.
 .IP \(bu 4
-"plain" \- optional file containing the plain text version of the body of the email template. If not present, it will be created from the HTML version.
+"plain" \- optional file containing the plain text version of the body of the email template. If not present, it
+will be created from the HTML version.
 .RE
+
+.SH JSON DATA
+If used with either the file or url sources, the JSON data file must have the following form.
+.nf
+.RS
+{
+  "name": "The name of the template in Civi",
+  "action": "create",
+  "subject": "The mail template subject line",
+  "creator_id": "960",
+  "from_email": "staff@example.org",
+  "from_name": "example",
+  "recipient": "",
+  "html": ".. html text ..",
+  "plain": ".. plain text .."
+}
+.RE
+.fi
+
+.SH EXAMPLES
+.PP
+The following reads a JSON data source at the example.com domain and constructs a template on
+the server at the example.org domain. No --action is specified, so the template is only created
+and no schedule is set for sending it.
+.PP
+.nf
+.RS
+mailcivi --civicrm=http://example.org/sites/all/modules/civicrm \\
+   --url=http://example.com/content_json/vor \\
+   --sitekey=fddfuhef1153ac --apikey=34o8vbeofu
+.RE
+.fi
+
+.PP
+The following reads the template data a local JSON file and creates a template on the server
+at the example.org domain. The recipients are set to those in the group with id '31' and assuming
+that such a group exists, the mail will be sent immediately.
+.PP
+.nf
+.RS
+mailcivi --action=send \\
+   --civicrm=http://example.org/sites/all/modules/civicrm \\
+   --json=local.json \\
+   --to_id=31 \\
+   --sitekey=fddfuhef1153ac --apikey=34o8vbeofu
+.RE
+
+.fi
+.PP
+The following reads the template data a local JSON file and creates a template on the server
+at the example.org domain. The recipients are set to those in the group with id '31' and assuming
+that such a group exists, the mail will be sent immediately.
 
 .SH SEE ALSO
 .IP \(bu 4

--- a/mailcivi/__init__.py
+++ b/mailcivi/__init__.py
@@ -10,7 +10,9 @@ __all__ = [
     'fetch_url',
     'connect_to_civi',
     'check_creator_exists',
-    'create_template'
+    'create_template',
+    'group_id_from_title',
+    'creator_id_from_name',
 ]
 
 from __main__ import mailcivi
@@ -18,3 +20,5 @@ from __main__ import CiviMailTemplate
 from __main__ import connect_to_civi
 from __main__ import check_creator_exists
 from __main__ import create_template
+from __main__ import creator_id_from_name
+from __main__ import group_id_from_title

--- a/mailcivi/__main__.py
+++ b/mailcivi/__main__.py
@@ -93,8 +93,8 @@ def getoptions():
                         help='Email Name for source of the email; overrides creator details. e.g. "Joe"')
 
     parser.add_argument('--action',
-                        choices=['nothing', 'store', 'send'],
-                        default='store',
+                        choices=['disable', 'create', 'send'],
+                        default='create',
                         help='What to do with the mail: nothing at all, upload it, or upload and send.')
 
     creatgroup = parser.add_mutually_exclusive_group(required=False)
@@ -161,7 +161,7 @@ def readjson(settings, civicrm, jsontemplate):
     if 'action' in jsontemplate:
         result.action = jsontemplate['action']
     else:
-        result.action = 'store'
+        result.action = 'create'
 
     result.html = jsontemplate['html']
     if 'plain' in jsontemplate:

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='elife-civiapi',
-    version='1.0.1',
+    version='1.1.0.2',
     install_requires=[
         "requests",
         "html2text",
@@ -14,7 +14,7 @@ setup(
     author_email='r.ivimeycook@elifesciences.org',
     description='Python script to read text of a CiviCRM mail template and create it on a Civi server.',
     classifiers=[
-        'Development Status :: 4 - Beta',
+        'Development Status :: 5 - Production',
         'Intended Audience :: Developers',
         'Programming Language :: Python :: 2.7',
     ],


### PR DESCRIPTION
_6 updated files in this update._

**Installation instructions**:

pip install https://github.com/elifesciences/elife-civiapi/archive/master.zip

**What's going on**:

The script has been updated to read an 'action' from JSON as well as the command line; action can cause the script to abort early (disable), to just create the mail template but not schedule it, or to create and then send it. The latter behaviour requires a patched version of python-civicrm to support the 'json' key in POST requests.

As well as the above, --creator is now supported with a name as well as an id, to enable the creating civi user to be set by name. Failure to lookup the id from this name is a fatal error.

The 'man' page for the command has been updated with usage details.

**Things to check**:
- mailcivi --help should include an option --action.
